### PR TITLE
Update endorlabs-to-gitlab.py

### DIFF
--- a/endorlabs-to-gitlab.py
+++ b/endorlabs-to-gitlab.py
@@ -100,7 +100,7 @@ def parse_findings_for_context(findings, context='all_findings'):
                     'value': xkey,
                     'url': f"https://nvd.nist.gov/vuln/detail/{xkey}"
                 }
-            elif xkey.index('://') > -1:
+            elif xkey.find('://') > -1:
                 if xkey.startswith('https://'):
                     xtra_id = {
                         'type': 'web',


### PR DESCRIPTION
xkey.index('://') > -1 is always expected to be True if the substring :// exists within xkey. if the substring isn't found, index() will throw a ValueError.

using find() instead of index(). find() returns -1 when the substring isn't found, rather than throwing an error.